### PR TITLE
Correct failure on exit when building as root

### DIFF
--- a/buildljt
+++ b/buildljt
@@ -34,7 +34,7 @@ onexit()
 {
 	cd $PREVDIR
 	if [ ! "$TMPDIR" = "" ]; then
-		RESULTS=`find $TMPDIR -uid 0`
+		RESULTS=`find $TMPDIR -uid 0 -print -quit`
 		if [ ! -z $RESULTS ]; then
 			sudo rm -rf $TMPDIR
 		else


### PR DESCRIPTION
When building as root, bash complains about to many arguments at comparison line 38.
Just tell `find` to exit once it printed the first path with uid=0